### PR TITLE
Add Github Actions workflow to publish image

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,0 +1,48 @@
+---
+name: Build and push the container images
+
+on:
+  push:
+    branches:
+      - main
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code for the target branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v1.6.0
+        with:
+          dockerfile: ./Dockerfile
+          failure-threshold: error
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to the container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push nvidia-gpu-exporter:${{ github.ref_name }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}"


### PR DESCRIPTION
This change adds a Github Action workflow that builds and push the
container image when a pull request is merged to the `main` or `vX.Y.Z`
branch.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>